### PR TITLE
fix bundle config so that @latest can be run by script import

### DIFF
--- a/widgets/package.json
+++ b/widgets/package.json
@@ -30,7 +30,7 @@
     "test": "jest --config=jest.config.ts",
     "lint": "eslint src",
     "dev": "webpack --mode=development",
-    "build": "rm -r dist; webpack --mode=production",
+    "build": "rm -r dist; mkdir dist; webpack --mode=production",
     "release": "release-it",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"

--- a/widgets/webpack.config.js
+++ b/widgets/webpack.config.js
@@ -8,9 +8,17 @@ module.exports = (env, { mode }) => {
     entry: isProduction
       ? {
           latest: './src/index.ts',
-          [PACKAGE.version]: './src/index.ts',
+          [PACKAGE.version]: {
+            import: './src/index.ts',
+            library: { type: 'commonjs-static' },
+          },
         }
-      : { [PACKAGE.version]: './src/index.ts' },
+      : {
+          [PACKAGE.version]: {
+            import: './src/index.ts',
+            library: { type: 'commonjs-static' },
+          },
+        },
     module: {
       rules: [
         {
@@ -27,7 +35,6 @@ module.exports = (env, { mode }) => {
       },
     },
     output: {
-      library: { type: 'commonjs-static' },
       filename: 'widgets@[name].js',
       path: path.resolve(__dirname, 'dist'),
     },


### PR DESCRIPTION
## Description
After adding the Widget package to NPM we changed the build to have a `commonJS` target, but we can only apply that to the semantic versioned bundle. fix bundle config so that @latest can be run by script import.

