### PR TITLE
7616958530 - Shopify widget updates

### DIFF
--- a/widgets/src/constants.ts
+++ b/widgets/src/constants.ts
@@ -6,6 +6,7 @@ export const DEFAULT_CONTAINER_CSS_SELECTOR = '[data-greenspark-widget-container
 export const WIDGET_TYPES = ['cart'] as const
 export const WIDGET_STYLES = ['default', 'simplified'] as const
 export const WIDGET_COLORS_V1 = ['beige', 'green', 'blue', 'white', 'black'] as const
+export const POPUP_THEMES = ['light', 'dark'] as const
 export const IMPACT_TYPES = ['trees', 'plastic', 'carbon', 'kelp', 'water'] as const
 export const WIDGET_COLORS = [
   'beige',

--- a/widgets/src/constants.ts
+++ b/widgets/src/constants.ts
@@ -6,6 +6,7 @@ export const DEFAULT_CONTAINER_CSS_SELECTOR = '[data-greenspark-widget-container
 export const WIDGET_TYPES = ['cart'] as const
 export const WIDGET_STYLES = ['default', 'simplified'] as const
 export const WIDGET_COLORS_V1 = ['beige', 'green', 'blue', 'white', 'black'] as const
+export const IMPACT_TYPES = ['trees', 'plastic', 'carbon', 'kelp', 'water'] as const
 export const WIDGET_COLORS = [
   'beige',
   'green',
@@ -16,11 +17,8 @@ export const WIDGET_COLORS = [
   'transparent',
 ] as const
 export const AVAILABLE_STATISTIC_TYPES = [
+  ...IMPACT_TYPES,
   'monthsEarthPositive',
-  'trees',
-  'plastic',
-  'carbon',
-  'kelp',
   'straws',
   'miles',
   'footballPitches',

--- a/widgets/src/interfaces/index.ts
+++ b/widgets/src/interfaces/index.ts
@@ -95,7 +95,7 @@ export interface PerProductWidgetParams extends WidgetParams, WidgetPopupParams,
 
 export interface TopStatsWidgetParams extends WidgetParams, WidgetPopupParams {
   color: (typeof WIDGET_COLORS)[number]
-  statTypes?: (typeof IMPACT_TYPES)[number][]
+  impactTypes?: (typeof IMPACT_TYPES)[number][]
 }
 
 export interface FullWidthBannerWidgetParams extends WidgetParams {

--- a/widgets/src/interfaces/index.ts
+++ b/widgets/src/interfaces/index.ts
@@ -4,14 +4,26 @@ import type {
   IMPACT_TYPES,
   WIDGET_COLORS,
   WIDGET_STYLES,
+  POPUP_THEMES,
 } from '@/constants'
 
 export type WidgetStyle = (typeof WIDGET_STYLES)[number]
+export type PopupTheme = (typeof POPUP_THEMES)[number]
 
 type ApiSettingsBase = {
   apiKey: string
   locale?: (typeof AVAILABLE_LOCALES)[number]
   isShopifyIntegration?: boolean
+}
+
+type WidgetPopupParams = {
+  withPopup?: boolean
+  popupTheme?: PopupTheme
+}
+
+type WidgetStyleParams = {
+  color: (typeof WIDGET_COLORS)[number]
+  style?: WidgetStyle
 }
 
 export type ApiSettings = ApiSettingsBase &
@@ -44,64 +56,46 @@ export interface WidgetParams {
   version?: 'v2'
 }
 
-export interface CartWidgetParams extends WidgetParams {
-  color: (typeof WIDGET_COLORS)[number]
+export interface CartWidgetParams extends WidgetParams, WidgetPopupParams, WidgetStyleParams {
   order: StoreOrder
-  withPopup?: boolean
-  style?: WidgetStyle
 }
 
-export interface SpendLevelWidgetParams extends WidgetParams {
-  color: (typeof WIDGET_COLORS)[number]
+export interface SpendLevelWidgetParams extends WidgetParams, WidgetPopupParams, WidgetStyleParams {
   currency: string
-  withPopup?: boolean
-  style?: WidgetStyle
 }
 
-export interface PerOrderWidgetParams extends WidgetParams {
-  color: (typeof WIDGET_COLORS)[number]
+export interface PerOrderWidgetParams extends WidgetParams, WidgetPopupParams, WidgetStyleParams {
   currency: string
-  withPopup?: boolean
-  style?: WidgetStyle
 }
 
-export interface PerPurchaseWidgetParams {
-  color: (typeof WIDGET_COLORS)[number]
+export interface PerPurchaseWidgetParams extends WidgetPopupParams, WidgetStyleParams {
   currency: string
-  withPopup?: boolean
-  style?: WidgetStyle
 }
 
-export interface ByPercentageWidgetParams extends WidgetParams {
-  color: (typeof WIDGET_COLORS)[number]
-  withPopup?: boolean
-  style?: WidgetStyle
-}
+export interface ByPercentageWidgetParams
+  extends WidgetParams,
+    WidgetPopupParams,
+    WidgetStyleParams {}
 
-export interface ByPercentageOfRevenueWidgetParams extends WidgetParams {
-  color: (typeof WIDGET_COLORS)[number]
-  withPopup?: boolean
-  style?: WidgetStyle
-}
+export interface ByPercentageOfRevenueWidgetParams
+  extends WidgetParams,
+    WidgetPopupParams,
+    WidgetStyleParams {}
 
-export interface TieredSpendLevelWidgetParams extends WidgetParams {
-  color: (typeof WIDGET_COLORS)[number]
+export interface TieredSpendLevelWidgetParams
+  extends WidgetParams,
+    WidgetPopupParams,
+    WidgetStyleParams {
   currency: string
-  withPopup?: boolean
-  style?: WidgetStyle
 }
 
-export interface PerProductWidgetParams extends WidgetParams {
-  color: (typeof WIDGET_COLORS)[number]
+export interface PerProductWidgetParams extends WidgetParams, WidgetPopupParams, WidgetStyleParams {
   productId: string
-  withPopup?: boolean
-  style?: WidgetStyle
 }
 
-export interface TopStatsWidgetParams extends WidgetParams {
+export interface TopStatsWidgetParams extends WidgetParams, WidgetPopupParams {
   color: (typeof WIDGET_COLORS)[number]
   statTypes?: (typeof IMPACT_TYPES)[number][]
-  withPopup?: boolean
 }
 
 export interface FullWidthBannerWidgetParams extends WidgetParams {

--- a/widgets/src/interfaces/index.ts
+++ b/widgets/src/interfaces/index.ts
@@ -100,7 +100,7 @@ export interface PerProductWidgetParams extends WidgetParams {
 
 export interface TopStatsWidgetParams extends WidgetParams {
   color: (typeof WIDGET_COLORS)[number]
-  impactTypes?: (typeof IMPACT_TYPES)[number][]
+  statTypes?: (typeof IMPACT_TYPES)[number][]
   withPopup?: boolean
 }
 

--- a/widgets/src/interfaces/index.ts
+++ b/widgets/src/interfaces/index.ts
@@ -1,6 +1,7 @@
 import type {
   AVAILABLE_LOCALES,
   AVAILABLE_STATISTIC_TYPES,
+  IMPACT_TYPES,
   WIDGET_COLORS,
   WIDGET_STYLES,
 } from '@/constants'
@@ -99,6 +100,7 @@ export interface PerProductWidgetParams extends WidgetParams {
 
 export interface TopStatsWidgetParams extends WidgetParams {
   color: (typeof WIDGET_COLORS)[number]
+  impactTypes?: (typeof IMPACT_TYPES)[number][]
   withPopup?: boolean
 }
 
@@ -108,6 +110,9 @@ export interface FullWidthBannerWidgetParams extends WidgetParams {
   title?: string
   description?: string
   callToActionUrl?: string
+  textColor?: string
+  buttonBackgroundColor?: string
+  buttonTextColor?: string
 }
 
 export type CartWidgetRequestBody = ExternalShopContext & CartWidgetParams
@@ -115,7 +120,8 @@ export type SpendLevelRequestBody = ExternalShopContext & SpendLevelWidgetParams
 export type PerOrderRequestBody = ExternalShopContext & PerOrderWidgetParams
 export type PerPurchaseRequestBody = ExternalShopContext & PerPurchaseWidgetParams
 export type ByPercentageRequestBody = ExternalShopContext & ByPercentageWidgetParams
-export type ByPercentageOfRevenueRequestBody = ExternalShopContext & ByPercentageOfRevenueWidgetParams
+export type ByPercentageOfRevenueRequestBody = ExternalShopContext &
+  ByPercentageOfRevenueWidgetParams
 export type TieredSpendLevelRequestBody = ExternalShopContext & TieredSpendLevelWidgetParams
 export type PerProductRequestBody = ExternalShopContext & PerProductWidgetParams
 export type TopStatsRequestBody = TopStatsWidgetParams

--- a/widgets/src/stories/Billing-widgets.stories.ts
+++ b/widgets/src/stories/Billing-widgets.stories.ts
@@ -1,5 +1,5 @@
 import { createWidgetPage } from '@/stories/Widgets'
-import { AVAILABLE_LOCALES, WIDGET_COLORS } from '@/constants'
+import { AVAILABLE_LOCALES, POPUP_THEMES, WIDGET_COLORS } from '@/constants'
 
 import type { StoryObj, Meta } from '@storybook/html'
 import type {
@@ -98,6 +98,10 @@ export const ByPercentage: StoryObj<{
   argTypes: {
     widgetArgs: {
       withPopup: { control: 'boolean' },
+      popupTheme: {
+        control: { type: 'select' },
+        options: POPUP_THEMES,
+      },
       color: {
         control: { type: 'select' },
         options: WIDGET_COLORS,
@@ -120,6 +124,10 @@ export const ByPercentageOfRevenue: StoryObj<{
   argTypes: {
     widgetArgs: {
       withPopup: { control: 'boolean' },
+      popupTheme: {
+        control: { type: 'select' },
+        options: POPUP_THEMES,
+      },
       color: {
         control: { type: 'select' },
         options: WIDGET_COLORS,
@@ -142,6 +150,10 @@ export const PerPurchase: StoryObj<{
   argTypes: {
     widgetArgs: {
       withPopup: { control: 'boolean' },
+      popupTheme: {
+        control: { type: 'select' },
+        options: POPUP_THEMES,
+      },
       currency: { control: 'text' },
       color: {
         control: { type: 'select' },
@@ -167,6 +179,10 @@ export const SpendLevel: StoryObj<{
     widgetArgs: {
       currency: { control: 'text' },
       withPopup: { control: 'boolean' },
+      popupTheme: {
+        control: { type: 'select' },
+        options: POPUP_THEMES,
+      },
       color: {
         control: { type: 'select' },
         options: WIDGET_COLORS,
@@ -190,6 +206,10 @@ export const TieredSpendLevel: StoryObj<{
   argTypes: {
     widgetArgs: {
       withPopup: { control: 'boolean' },
+      popupTheme: {
+        control: { type: 'select' },
+        options: POPUP_THEMES,
+      },
       currency: { control: 'text' },
       color: {
         control: { type: 'select' },

--- a/widgets/src/stories/Widgets.stories.ts
+++ b/widgets/src/stories/Widgets.stories.ts
@@ -79,6 +79,7 @@ const meta = {
       { withPopup: true },
       { version: 'v2', withPopup: false },
       { version: 'v2', withPopup: true },
+      { version: 'v2', withPopup: true, popupTheme: 'dark' },
     ]
 
     const newVariants = [
@@ -351,12 +352,11 @@ export const TopStats: StoryObj<{
     widgetArgs: {
       color: {
         control: { type: 'select' },
-        options: WIDGET_COLORS,
       },
       withPopup: { control: 'boolean' },
-      statTypes: {
+      impactTypes: {
         control: { type: 'select' },
-        options: IMPACT_TYPES,
+        options: IMPACT_TYPES.filter,
         withPopup: { control: 'boolean' },
       },
     },

--- a/widgets/src/stories/Widgets.stories.ts
+++ b/widgets/src/stories/Widgets.stories.ts
@@ -1,5 +1,10 @@
 import { createWidgetPage } from '@/stories/Widgets'
-import { AVAILABLE_LOCALES, AVAILABLE_STATISTIC_TYPES, WIDGET_COLORS } from '@/constants'
+import {
+  AVAILABLE_LOCALES,
+  AVAILABLE_STATISTIC_TYPES,
+  IMPACT_TYPES,
+  WIDGET_COLORS,
+} from '@/constants'
 
 import type { StoryObj, Meta } from '@storybook/html'
 import type {
@@ -233,6 +238,9 @@ export const FullWidthBanner: StoryObj<{
   args: {
     widgetArgs: {
       options: [...AVAILABLE_STATISTIC_TYPES],
+      textColor: 'red',
+      buttonBackgroundColor: 'pink',
+      buttonTextColor: '#4433f4',
     },
     widgetType: 'fullWidthBanner',
   },
@@ -343,6 +351,11 @@ export const TopStats: StoryObj<{
       color: {
         control: { type: 'select' },
         options: WIDGET_COLORS,
+      },
+      withPopup: { control: 'boolean' },
+      impactTypes: {
+        control: { type: 'select' },
+        options: IMPACT_TYPES,
         withPopup: { control: 'boolean' },
       },
     },

--- a/widgets/src/stories/Widgets.stories.ts
+++ b/widgets/src/stories/Widgets.stories.ts
@@ -48,9 +48,10 @@ const meta = {
     })
 
     const basicVariants = [
-      { version: '', style: 'default' },
-      { version: 'v2', style: 'default' },
-      { version: 'v2', style: 'simplified' },
+      { version: '', style: 'default', withPopup: false },
+      { version: 'v2', style: 'default', withPopup: false },
+      { version: 'v2', style: 'default', withPopup: true, popupTheme: 'dark' },
+      { version: 'v2', style: 'simplified', withPopup: true, popupTheme: 'light' },
     ]
 
     const fullWidthIcons = ['monthsEarthPositive', 'trees', 'plastic', 'carbon', 'kelp', 'straws']
@@ -76,7 +77,7 @@ const meta = {
 
     const topStatsVariants = [
       { withPopup: true },
-      { version: 'v2' },
+      { version: 'v2', withPopup: false },
       { version: 'v2', withPopup: true },
     ]
 

--- a/widgets/src/stories/Widgets.stories.ts
+++ b/widgets/src/stories/Widgets.stories.ts
@@ -363,7 +363,6 @@ export const TopStats: StoryObj<{
   args: {
     widgetArgs: {
       color: 'beige',
-      statTypes: ['water', 'trees'],
     },
     widgetType: 'topStats',
   },

--- a/widgets/src/stories/Widgets.stories.ts
+++ b/widgets/src/stories/Widgets.stories.ts
@@ -353,7 +353,7 @@ export const TopStats: StoryObj<{
         options: WIDGET_COLORS,
       },
       withPopup: { control: 'boolean' },
-      impactTypes: {
+      statTypes: {
         control: { type: 'select' },
         options: IMPACT_TYPES,
         withPopup: { control: 'boolean' },
@@ -363,6 +363,7 @@ export const TopStats: StoryObj<{
   args: {
     widgetArgs: {
       color: 'beige',
+      statTypes: ['water', 'trees'],
     },
     widgetType: 'topStats',
   },

--- a/widgets/src/widgets/byPercentage.ts
+++ b/widgets/src/widgets/byPercentage.ts
@@ -2,11 +2,12 @@ import { Widget } from '@/widgets/base'
 import { WIDGET_COLORS } from '@/constants'
 
 import type { WidgetConfig } from '@/widgets/base'
-import type { ByPercentageWidgetParams, WidgetStyle } from '@/interfaces'
+import type { ByPercentageWidgetParams, PopupTheme, WidgetStyle } from '@/interfaces'
 
 export class ByPercentageWidget extends Widget implements ByPercentageWidgetParams {
   color: (typeof WIDGET_COLORS)[number]
   withPopup?: boolean
+  popupTheme?: PopupTheme
   style?: WidgetStyle
   version?: 'v2'
 
@@ -14,6 +15,7 @@ export class ByPercentageWidget extends Widget implements ByPercentageWidgetPara
     super(params)
     this.color = params.color
     this.withPopup = params.withPopup ?? true
+    this.popupTheme = params.popupTheme
     this.style = params.style ?? 'default'
     this.version = params.version
   }
@@ -22,14 +24,22 @@ export class ByPercentageWidget extends Widget implements ByPercentageWidgetPara
     return {
       color: this.color,
       withPopup: this.withPopup,
+      popupTheme: this.popupTheme,
       style: this.style,
       version: this.version,
     }
   }
 
-  updateDefaults({ color, withPopup, style, version }: Partial<ByPercentageWidgetParams>) {
+  updateDefaults({
+    color,
+    withPopup,
+    popupTheme,
+    style,
+    version,
+  }: Partial<ByPercentageWidgetParams>) {
     this.color = color ?? this.color
     this.withPopup = withPopup ?? this.withPopup
+    this.popupTheme = popupTheme ?? this.popupTheme
     this.style = style ?? this.style
     this.version = version ?? this.version
   }

--- a/widgets/src/widgets/byPercentageOfRevenue.ts
+++ b/widgets/src/widgets/byPercentageOfRevenue.ts
@@ -2,14 +2,15 @@ import { Widget } from '@/widgets/base'
 import { WIDGET_COLORS } from '@/constants'
 
 import type { WidgetConfig } from '@/widgets/base'
-import type {
-  ByPercentageOfRevenueWidgetParams,
-  WidgetStyle
-} from '@/interfaces'
+import type { ByPercentageOfRevenueWidgetParams, PopupTheme, WidgetStyle } from '@/interfaces'
 
-export class ByPercentageOfRevenueWidget extends Widget implements ByPercentageOfRevenueWidgetParams {
+export class ByPercentageOfRevenueWidget
+  extends Widget
+  implements ByPercentageOfRevenueWidgetParams
+{
   color: (typeof WIDGET_COLORS)[number]
   withPopup?: boolean
+  popupTheme?: PopupTheme
   style?: WidgetStyle
   version?: 'v2'
 
@@ -17,6 +18,7 @@ export class ByPercentageOfRevenueWidget extends Widget implements ByPercentageO
     super(params)
     this.color = params.color
     this.withPopup = params.withPopup ?? true
+    this.popupTheme = params.popupTheme
     this.style = params.style ?? 'default'
     this.version = params.version
   }
@@ -25,14 +27,22 @@ export class ByPercentageOfRevenueWidget extends Widget implements ByPercentageO
     return {
       color: this.color,
       withPopup: this.withPopup,
+      popupTheme: this.popupTheme,
       style: this.style,
       version: this.version,
     }
   }
 
-  updateDefaults({ color, withPopup, style, version }: Partial<ByPercentageOfRevenueWidgetParams>) {
+  updateDefaults({
+    color,
+    withPopup,
+    popupTheme,
+    style,
+    version,
+  }: Partial<ByPercentageOfRevenueWidgetParams>) {
     this.color = color ?? this.color
     this.withPopup = withPopup ?? this.withPopup
+    this.popupTheme = popupTheme ?? this.popupTheme
     this.style = style ?? this.style
     this.version = version ?? this.version
   }
@@ -60,11 +70,15 @@ export class ByPercentageOfRevenueWidget extends Widget implements ByPercentageO
   async renderToString(options?: Partial<ByPercentageOfRevenueWidgetParams>): Promise<string> {
     if (options) this.updateDefaults(options)
     this.validateOptions()
-    const response = await this.api.fetchByPercentageOfRevenueWidget(this.byPercentageOfRevenueWidgetRequestBody)
+    const response = await this.api.fetchByPercentageOfRevenueWidget(
+      this.byPercentageOfRevenueWidgetRequestBody,
+    )
     return response.data
   }
 
-  async renderToElement(options?: Partial<ByPercentageOfRevenueWidgetParams>): Promise<HTMLElement> {
+  async renderToElement(
+    options?: Partial<ByPercentageOfRevenueWidgetParams>,
+  ): Promise<HTMLElement> {
     const html = await this.renderToString(options)
     return this.parseHtml(html)
   }

--- a/widgets/src/widgets/cart.ts
+++ b/widgets/src/widgets/cart.ts
@@ -2,12 +2,19 @@ import { Widget } from '@/widgets/base'
 import { WIDGET_COLORS } from '@/constants'
 
 import type { WidgetConfig } from '@/widgets/base'
-import type { OrderProduct, CartWidgetParams, StoreOrder, WidgetStyle } from '@/interfaces'
+import type {
+  OrderProduct,
+  CartWidgetParams,
+  StoreOrder,
+  WidgetStyle,
+  PopupTheme,
+} from '@/interfaces'
 
 export class CartWidget extends Widget implements CartWidgetParams {
   color: (typeof WIDGET_COLORS)[number]
   order: StoreOrder
   withPopup?: boolean
+  popupTheme?: PopupTheme
   style?: WidgetStyle
   version?: 'v2'
 
@@ -16,6 +23,7 @@ export class CartWidget extends Widget implements CartWidgetParams {
     this.color = params.color
     this.order = params.order
     this.withPopup = params.withPopup ?? true
+    this.popupTheme = params.popupTheme
     this.style = params.style ?? 'default'
     this.version = params.version
   }
@@ -25,15 +33,24 @@ export class CartWidget extends Widget implements CartWidgetParams {
       color: this.color,
       order: this.order,
       withPopup: this.withPopup,
+      popupTheme: this.popupTheme,
       style: this.style,
       version: this.version,
     }
   }
 
-  updateDefaults({ color, order, withPopup, style, version }: Partial<CartWidgetParams>) {
+  updateDefaults({
+    color,
+    order,
+    withPopup,
+    popupTheme,
+    style,
+    version,
+  }: Partial<CartWidgetParams>) {
     this.color = color ?? this.color
     this.order = order ?? this.order
     this.withPopup = withPopup ?? this.withPopup
+    this.popupTheme = popupTheme ?? this.popupTheme
     this.style = style ?? this.style
     this.version = version ?? this.version
   }

--- a/widgets/src/widgets/fullWidthBanner.ts
+++ b/widgets/src/widgets/fullWidthBanner.ts
@@ -10,6 +10,9 @@ export class FullWidthBannerWidget extends Widget implements FullWidthBannerWidg
   title?: string
   description?: string
   callToActionUrl?: string
+  textColor?: string
+  buttonBackgroundColor?: string
+  buttonTextColor?: string
   version?: 'v2'
 
   constructor(params: WidgetConfig & FullWidthBannerWidgetParams) {
@@ -19,6 +22,9 @@ export class FullWidthBannerWidget extends Widget implements FullWidthBannerWidg
     this.title = params.title
     this.description = params.description
     this.callToActionUrl = params.callToActionUrl
+    this.textColor = params.textColor
+    this.buttonBackgroundColor = params.buttonBackgroundColor
+    this.buttonTextColor = params.buttonTextColor
     this.version = params.version
   }
 
@@ -29,6 +35,9 @@ export class FullWidthBannerWidget extends Widget implements FullWidthBannerWidg
       title: this.title,
       description: this.description,
       callToActionUrl: this.callToActionUrl,
+      textColor: this.textColor,
+      buttonBackgroundColor: this.buttonBackgroundColor,
+      buttonTextColor: this.buttonTextColor,
       version: this.version,
     }
   }
@@ -39,6 +48,9 @@ export class FullWidthBannerWidget extends Widget implements FullWidthBannerWidg
     title,
     description,
     callToActionUrl,
+    textColor,
+    buttonBackgroundColor,
+    buttonTextColor,
     version,
   }: Partial<FullWidthBannerWidgetParams>) {
     this.options = options ?? this.options
@@ -46,6 +58,9 @@ export class FullWidthBannerWidget extends Widget implements FullWidthBannerWidg
     this.title = title ?? this.title
     this.description = description ?? this.description
     this.callToActionUrl = callToActionUrl ?? this.callToActionUrl
+    this.textColor = textColor ?? this.textColor
+    this.buttonBackgroundColor = buttonBackgroundColor ?? this.buttonBackgroundColor
+    this.buttonTextColor = buttonTextColor ?? this.buttonTextColor
     this.version = version ?? this.version
   }
 

--- a/widgets/src/widgets/perOrder.ts
+++ b/widgets/src/widgets/perOrder.ts
@@ -2,12 +2,13 @@ import { Widget } from '@/widgets/base'
 import { WIDGET_COLORS } from '@/constants'
 
 import type { WidgetConfig } from '@/widgets/base'
-import type { PerOrderWidgetParams, WidgetStyle } from '@/interfaces'
+import type { PerOrderWidgetParams, PopupTheme, WidgetStyle } from '@/interfaces'
 
 export class PerOrderWidget extends Widget implements PerOrderWidgetParams {
   color: (typeof WIDGET_COLORS)[number]
   currency: string
   withPopup?: boolean
+  popupTheme?: PopupTheme
   style?: WidgetStyle
   version?: 'v2'
 
@@ -16,6 +17,7 @@ export class PerOrderWidget extends Widget implements PerOrderWidgetParams {
     this.color = params.color
     this.currency = params.currency
     this.withPopup = params.withPopup ?? true
+    this.popupTheme = params.popupTheme
     this.style = params.style ?? 'default'
     this.version = params.version
   }
@@ -25,15 +27,24 @@ export class PerOrderWidget extends Widget implements PerOrderWidgetParams {
       color: this.color,
       currency: this.currency,
       withPopup: this.withPopup,
+      popupTheme: this.popupTheme,
       style: this.style,
       version: this.version,
     }
   }
 
-  updateDefaults({ color, currency, withPopup, style, version }: Partial<PerOrderWidgetParams>) {
+  updateDefaults({
+    color,
+    currency,
+    withPopup,
+    popupTheme,
+    style,
+    version,
+  }: Partial<PerOrderWidgetParams>) {
     this.color = color ?? this.color
     this.currency = currency ?? this.currency
     this.withPopup = withPopup ?? this.withPopup
+    this.popupTheme = popupTheme ?? this.popupTheme
     this.style = style ?? this.style
     this.version = version ?? this.version
   }

--- a/widgets/src/widgets/perProduct.ts
+++ b/widgets/src/widgets/perProduct.ts
@@ -2,12 +2,13 @@ import { Widget } from '@/widgets/base'
 import { WIDGET_COLORS } from '@/constants'
 
 import type { WidgetConfig } from '@/widgets/base'
-import type { PerProductWidgetParams, WidgetStyle } from '@/interfaces'
+import type { PerProductWidgetParams, PopupTheme, WidgetStyle } from '@/interfaces'
 
 export class PerProductWidget extends Widget implements PerProductWidgetParams {
   color: (typeof WIDGET_COLORS)[number]
   productId: string
   withPopup?: boolean
+  popupTheme?: PopupTheme
   style?: WidgetStyle
   version?: 'v2'
 
@@ -16,6 +17,7 @@ export class PerProductWidget extends Widget implements PerProductWidgetParams {
     this.color = params.color
     this.productId = params.productId
     this.withPopup = params.withPopup ?? true
+    this.popupTheme = params.popupTheme
     this.style = params.style ?? 'default'
     this.version = params.version
   }
@@ -25,15 +27,24 @@ export class PerProductWidget extends Widget implements PerProductWidgetParams {
       color: this.color,
       productId: this.productId,
       withPopup: this.withPopup,
+      popupTheme: this.popupTheme,
       style: this.style,
       version: this.version,
     }
   }
 
-  updateDefaults({ color, productId, withPopup, style, version }: Partial<PerProductWidgetParams>) {
+  updateDefaults({
+    color,
+    productId,
+    withPopup,
+    popupTheme,
+    style,
+    version,
+  }: Partial<PerProductWidgetParams>) {
     this.color = color ?? this.color
     this.productId = productId ?? this.productId
     this.withPopup = withPopup ?? this.withPopup
+    this.popupTheme = popupTheme ?? this.popupTheme
     this.style = style ?? this.style
     this.version = version ?? this.version
   }

--- a/widgets/src/widgets/perPurchase.ts
+++ b/widgets/src/widgets/perPurchase.ts
@@ -2,12 +2,13 @@ import { Widget } from '@/widgets/base'
 import { WIDGET_COLORS } from '@/constants'
 
 import type { WidgetConfig } from '@/widgets/base'
-import type { PerPurchaseWidgetParams, WidgetParams, WidgetStyle } from '@/interfaces'
+import type { PerPurchaseWidgetParams, PopupTheme, WidgetParams, WidgetStyle } from '@/interfaces'
 
 export class PerPurchaseWidget extends Widget implements PerPurchaseWidgetParams {
   color: (typeof WIDGET_COLORS)[number]
   currency: string
   withPopup?: boolean
+  popupTheme?: PopupTheme
   style?: WidgetStyle
   version: 'v2'
 
@@ -16,6 +17,7 @@ export class PerPurchaseWidget extends Widget implements PerPurchaseWidgetParams
     this.color = params.color
     this.currency = params.currency
     this.withPopup = params.withPopup ?? true
+    this.popupTheme = params.popupTheme
     this.style = params.style ?? 'default'
     this.version = params.version
   }
@@ -25,6 +27,7 @@ export class PerPurchaseWidget extends Widget implements PerPurchaseWidgetParams
       color: this.color,
       currency: this.currency,
       withPopup: this.withPopup,
+      popupTheme: this.popupTheme,
       style: this.style,
       version: this.version,
     }
@@ -34,12 +37,14 @@ export class PerPurchaseWidget extends Widget implements PerPurchaseWidgetParams
     color,
     currency,
     withPopup,
+    popupTheme,
     style,
     version,
   }: Partial<PerPurchaseWidgetParams> & Required<WidgetParams>) {
     this.color = color ?? this.color
     this.currency = currency ?? this.currency
     this.withPopup = withPopup ?? this.withPopup
+    this.popupTheme = popupTheme ?? this.popupTheme
     this.style = style ?? this.style
     this.version = version ?? this.version
   }

--- a/widgets/src/widgets/spendLevel.ts
+++ b/widgets/src/widgets/spendLevel.ts
@@ -2,12 +2,13 @@ import { Widget } from '@/widgets/base'
 import { WIDGET_COLORS } from '@/constants'
 
 import type { WidgetConfig } from '@/widgets/base'
-import type { SpendLevelWidgetParams, WidgetStyle } from '@/interfaces'
+import type { PopupTheme, SpendLevelWidgetParams, WidgetStyle } from '@/interfaces'
 
 export class SpendLevelWidget extends Widget implements SpendLevelWidgetParams {
   color: (typeof WIDGET_COLORS)[number]
   currency: string
   withPopup?: boolean
+  popupTheme?: PopupTheme
   style?: WidgetStyle
   version?: 'v2'
 
@@ -16,6 +17,7 @@ export class SpendLevelWidget extends Widget implements SpendLevelWidgetParams {
     this.color = params.color
     this.currency = params.currency
     this.withPopup = params.withPopup ?? true
+    this.popupTheme = params.popupTheme
     this.style = params.style ?? 'default'
     this.version = params.version
   }
@@ -25,15 +27,24 @@ export class SpendLevelWidget extends Widget implements SpendLevelWidgetParams {
       color: this.color,
       currency: this.currency,
       withPopup: this.withPopup,
+      popupTheme: this.popupTheme,
       style: this.style,
       version: this.version,
     }
   }
 
-  updateDefaults({ color, currency, withPopup, style, version }: Partial<SpendLevelWidgetParams>) {
+  updateDefaults({
+    color,
+    currency,
+    withPopup,
+    popupTheme,
+    style,
+    version,
+  }: Partial<SpendLevelWidgetParams>) {
     this.color = color ?? this.color
     this.currency = currency ?? this.currency
     this.withPopup = withPopup ?? this.withPopup
+    this.popupTheme = popupTheme ?? this.popupTheme
     this.style = style ?? this.style
     this.version = version ?? this.version
   }

--- a/widgets/src/widgets/tieredSpendLevel.ts
+++ b/widgets/src/widgets/tieredSpendLevel.ts
@@ -2,12 +2,13 @@ import { Widget } from '@/widgets/base'
 import { WIDGET_COLORS } from '@/constants'
 
 import type { WidgetConfig } from '@/widgets/base'
-import type { TieredSpendLevelWidgetParams, WidgetStyle } from '@/interfaces'
+import type { PopupTheme, TieredSpendLevelWidgetParams, WidgetStyle } from '@/interfaces'
 
 export class TieredSpendLevelWidget extends Widget implements TieredSpendLevelWidgetParams {
   color: (typeof WIDGET_COLORS)[number]
   currency: string
   withPopup?: boolean
+  popupTheme?: PopupTheme
   style?: WidgetStyle
   version?: 'v2'
 
@@ -16,6 +17,7 @@ export class TieredSpendLevelWidget extends Widget implements TieredSpendLevelWi
     this.color = params.color
     this.currency = params.currency
     this.withPopup = params.withPopup ?? true
+    this.popupTheme = params.popupTheme
     this.style = params.style ?? 'default'
     this.version = params.version
   }
@@ -25,6 +27,7 @@ export class TieredSpendLevelWidget extends Widget implements TieredSpendLevelWi
       color: this.color,
       currency: this.currency,
       withPopup: this.withPopup,
+      popupTheme: this.popupTheme,
       style: this.style,
       version: this.version,
     }
@@ -34,12 +37,14 @@ export class TieredSpendLevelWidget extends Widget implements TieredSpendLevelWi
     color,
     currency,
     withPopup,
+    popupTheme,
     version,
     style,
   }: Partial<TieredSpendLevelWidgetParams>) {
     this.color = color ?? this.color
     this.currency = currency ?? this.currency
     this.withPopup = withPopup ?? this.withPopup
+    this.popupTheme = popupTheme ?? this.popupTheme
     this.version = version ?? this.version
     this.style = style ?? this.style
   }

--- a/widgets/src/widgets/topStats.ts
+++ b/widgets/src/widgets/topStats.ts
@@ -7,13 +7,13 @@ import type { TopStatsWidgetParams } from '@/interfaces'
 export class TopStatsWidget extends Widget implements TopStatsWidgetParams {
   color: (typeof WIDGET_COLORS)[number]
   withPopup?: boolean
-  impactTypes?: (typeof IMPACT_TYPES)[number][]
+  statTypes?: (typeof IMPACT_TYPES)[number][]
   version?: 'v2'
 
   constructor(params: WidgetConfig & TopStatsWidgetParams) {
     super(params)
     this.color = params.color
-    this.impactTypes = params.impactTypes
+    this.statTypes = params.statTypes
     this.withPopup = params.withPopup
     this.version = params.version
   }
@@ -21,15 +21,15 @@ export class TopStatsWidget extends Widget implements TopStatsWidgetParams {
   get topStatsWidgetRequestBody(): TopStatsWidgetParams {
     return {
       color: this.color,
-      impactTypes: this.impactTypes,
+      statTypes: this.statTypes,
       withPopup: this.withPopup,
       version: this.version,
     }
   }
 
-  updateDefaults({ color, impactTypes, withPopup, version }: Partial<TopStatsWidgetParams>) {
+  updateDefaults({ color, statTypes, withPopup, version }: Partial<TopStatsWidgetParams>) {
     this.color = color ?? this.color
-    this.impactTypes = impactTypes ?? this.impactTypes
+    this.statTypes = statTypes ?? this.statTypes
     this.withPopup = withPopup ?? this.withPopup
     this.version = version ?? this.version
   }
@@ -44,10 +44,10 @@ export class TopStatsWidget extends Widget implements TopStatsWidgetParams {
         )}`,
       )
     }
-    if (this.impactTypes && this.impactTypes.some((i) => !IMPACT_TYPES.includes(i))) {
+    if (this.statTypes && this.statTypes.some((s) => !IMPACT_TYPES.includes(s))) {
       throw new Error(
         `Greenspark - "${
-          this.impactTypes
+          this.statTypes
         }" is not a valid list for the displayed values of the Top Stats Widget. Please use only the available types: ${IMPACT_TYPES.join(
           ', ',
         )}`,

--- a/widgets/src/widgets/topStats.ts
+++ b/widgets/src/widgets/topStats.ts
@@ -1,5 +1,5 @@
 import { Widget } from '@/widgets/base'
-import { WIDGET_COLORS } from '@/constants'
+import { WIDGET_COLORS, IMPACT_TYPES } from '@/constants'
 
 import type { WidgetConfig } from '@/widgets/base'
 import type { TopStatsWidgetParams } from '@/interfaces'
@@ -7,11 +7,13 @@ import type { TopStatsWidgetParams } from '@/interfaces'
 export class TopStatsWidget extends Widget implements TopStatsWidgetParams {
   color: (typeof WIDGET_COLORS)[number]
   withPopup?: boolean
+  impactTypes?: (typeof IMPACT_TYPES)[number][]
   version?: 'v2'
 
   constructor(params: WidgetConfig & TopStatsWidgetParams) {
     super(params)
     this.color = params.color
+    this.impactTypes = params.impactTypes
     this.withPopup = params.withPopup
     this.version = params.version
   }
@@ -19,13 +21,15 @@ export class TopStatsWidget extends Widget implements TopStatsWidgetParams {
   get topStatsWidgetRequestBody(): TopStatsWidgetParams {
     return {
       color: this.color,
+      impactTypes: this.impactTypes,
       withPopup: this.withPopup,
       version: this.version,
     }
   }
 
-  updateDefaults({ color, withPopup, version }: Partial<TopStatsWidgetParams>) {
+  updateDefaults({ color, impactTypes, withPopup, version }: Partial<TopStatsWidgetParams>) {
     this.color = color ?? this.color
+    this.impactTypes = impactTypes ?? this.impactTypes
     this.withPopup = withPopup ?? this.withPopup
     this.version = version ?? this.version
   }
@@ -36,6 +40,15 @@ export class TopStatsWidget extends Widget implements TopStatsWidgetParams {
         `Greenspark - "${
           this.color
         }" was selected as the color for the Top Stats Widget, but this color is not available. Please use one of the available colors: ${WIDGET_COLORS.join(
+          ', ',
+        )}`,
+      )
+    }
+    if (this.impactTypes && this.impactTypes.some((i) => !IMPACT_TYPES.includes(i))) {
+      throw new Error(
+        `Greenspark - "${
+          this.impactTypes
+        }" is not a valid list for the displayed values of the Top Stats Widget. Please use only the available types: ${IMPACT_TYPES.join(
           ', ',
         )}`,
       )

--- a/widgets/src/widgets/topStats.ts
+++ b/widgets/src/widgets/topStats.ts
@@ -8,13 +8,13 @@ export class TopStatsWidget extends Widget implements TopStatsWidgetParams {
   color: (typeof WIDGET_COLORS)[number]
   withPopup?: boolean
   popupTheme?: PopupTheme
-  statTypes?: (typeof IMPACT_TYPES)[number][]
+  impactTypes?: (typeof IMPACT_TYPES)[number][]
   version?: 'v2'
 
   constructor(params: WidgetConfig & TopStatsWidgetParams) {
     super(params)
     this.color = params.color
-    this.statTypes = params.statTypes
+    this.impactTypes = params.impactTypes
     this.withPopup = params.withPopup
     this.popupTheme = params.popupTheme
     this.version = params.version
@@ -23,7 +23,7 @@ export class TopStatsWidget extends Widget implements TopStatsWidgetParams {
   get topStatsWidgetRequestBody(): TopStatsWidgetParams {
     return {
       color: this.color,
-      statTypes: this.statTypes,
+      impactTypes: this.impactTypes,
       withPopup: this.withPopup,
       popupTheme: this.popupTheme,
       version: this.version,
@@ -32,13 +32,13 @@ export class TopStatsWidget extends Widget implements TopStatsWidgetParams {
 
   updateDefaults({
     color,
-    statTypes,
+    impactTypes,
     withPopup,
     popupTheme,
     version,
   }: Partial<TopStatsWidgetParams>) {
     this.color = color ?? this.color
-    this.statTypes = statTypes ?? this.statTypes
+    this.impactTypes = impactTypes ?? this.impactTypes
     this.withPopup = withPopup ?? this.withPopup
     this.popupTheme = popupTheme ?? this.popupTheme
     this.version = version ?? this.version
@@ -54,10 +54,10 @@ export class TopStatsWidget extends Widget implements TopStatsWidgetParams {
         )}`,
       )
     }
-    if (this.statTypes && this.statTypes.some((s) => !IMPACT_TYPES.includes(s))) {
+    if (this.impactTypes && this.impactTypes.some((s) => !IMPACT_TYPES.includes(s))) {
       throw new Error(
         `Greenspark - "${
-          this.statTypes
+          this.impactTypes
         }" is not a valid list for the displayed values of the Top Stats Widget. Please use only the available types: ${IMPACT_TYPES.join(
           ', ',
         )}`,

--- a/widgets/src/widgets/topStats.ts
+++ b/widgets/src/widgets/topStats.ts
@@ -2,11 +2,12 @@ import { Widget } from '@/widgets/base'
 import { WIDGET_COLORS, IMPACT_TYPES } from '@/constants'
 
 import type { WidgetConfig } from '@/widgets/base'
-import type { TopStatsWidgetParams } from '@/interfaces'
+import type { PopupTheme, TopStatsWidgetParams } from '@/interfaces'
 
 export class TopStatsWidget extends Widget implements TopStatsWidgetParams {
   color: (typeof WIDGET_COLORS)[number]
   withPopup?: boolean
+  popupTheme?: PopupTheme
   statTypes?: (typeof IMPACT_TYPES)[number][]
   version?: 'v2'
 
@@ -15,6 +16,7 @@ export class TopStatsWidget extends Widget implements TopStatsWidgetParams {
     this.color = params.color
     this.statTypes = params.statTypes
     this.withPopup = params.withPopup
+    this.popupTheme = params.popupTheme
     this.version = params.version
   }
 
@@ -23,14 +25,22 @@ export class TopStatsWidget extends Widget implements TopStatsWidgetParams {
       color: this.color,
       statTypes: this.statTypes,
       withPopup: this.withPopup,
+      popupTheme: this.popupTheme,
       version: this.version,
     }
   }
 
-  updateDefaults({ color, statTypes, withPopup, version }: Partial<TopStatsWidgetParams>) {
+  updateDefaults({
+    color,
+    statTypes,
+    withPopup,
+    popupTheme,
+    version,
+  }: Partial<TopStatsWidgetParams>) {
     this.color = color ?? this.color
     this.statTypes = statTypes ?? this.statTypes
     this.withPopup = withPopup ?? this.withPopup
+    this.popupTheme = popupTheme ?? this.popupTheme
     this.version = version ?? this.version
   }
 


### PR DESCRIPTION
## Description:
- allow users to change the CTA & text colours on the full width banner
- allow users to toggle which impacts they want to show on the top stats widget
- allow users to choose which pop-up they want to show, light or dark theme (or not showing any popups)

### Depends on
https://github.com/getgreenspark/monorepo/pull/1098

### Link to task/bug:
https://greenspark-force.monday.com/boards/3658967791/views/83096355/pulses/7616958530
