### PR TITLE
add widget sdk load script

### DIFF
--- a/widgets-shopify/package.json
+++ b/widgets-shopify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getgreenspark/widgets-shopify",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "bugs": {
     "url": "https://github.com/getgreenspark/sdks/issues"
   },

--- a/widgets-shopify/src/index.ts
+++ b/widgets-shopify/src/index.ts
@@ -1,4 +1,3 @@
-import GreensparkWidgets from '@/index'
 import type { WidgetStyle } from '@/interfaces'
 import type { AVAILABLE_LOCALES, WIDGET_COLORS } from '@/constants'
 
@@ -52,7 +51,7 @@ function runGreenspark() {
     cartEl.insertAdjacentHTML('afterbegin', '<div data-greenspark-widget-target></div>')
   }
 
-  const greenspark = new GreensparkWidgets({
+  const greenspark = new window.GreensparkWidgets({
     apiKey,
     locale,
     integrationSlug: shopUniqueName,
@@ -100,7 +99,37 @@ function runGreenspark() {
     })
 }
 
-runGreenspark()
+function loadScript(url: string): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const script = document.createElement('script')
+    script.type = 'text/javascript'
+    script.onload = function () {
+      resolve()
+    }
+
+    script.src = url
+    const head = document.querySelector('head')
+
+    if (head) {
+      head.appendChild(script)
+    }
+  })
+}
+
+async function setup() {
+  if (window.GreensparkWidgets) return
+  await loadScript('https://cdn.getgreenspark.com/scripts/widgets%40latest.js')
+  window.dispatchEvent(new Event('greenspark-setup'))
+}
+
+setup().catch((e) => console.error('Greenspark Widget -', e))
+
+if (!window.GreensparkWidgets) {
+  window.addEventListener('greenspark-setup', runGreenspark, { once: true })
+} else {
+  runGreenspark()
+}
+
 ;(function (context, fetch) {
   if (typeof fetch !== 'function') return
 


### PR DESCRIPTION
## Description
Load widget sdk latest version with a script tag instead of importing it as a module and including in the bundle. Reason being is that the path alias gets a bit tricky between the two sub folders and the build fails because of it. It doesnt properly recognise the @ alias for the src in both sub folders. 

### Implementation choices:

### Link to task/bug:
https://greenspark-force.monday.com/boards/3658967791/views/83096355/pulses/7859764398