### PR TITLE
Organise test users

### DIFF
--- a/widgets/src/stories/Billing-widgets.stories.ts
+++ b/widgets/src/stories/Billing-widgets.stories.ts
@@ -1,6 +1,5 @@
 import { createWidgetPage } from '@/stories/Widgets'
 import { AVAILABLE_LOCALES, POPUP_THEMES, WIDGET_COLORS } from '@/constants'
-
 import type { StoryObj, Meta } from '@storybook/html'
 import type {
   ByPercentageWidgetParams,
@@ -12,10 +11,8 @@ import type {
 } from '@/interfaces'
 import GreensparkWidgets from '@/index'
 import type { Widget } from '@/widgets/base'
+import { BILLING_USERS as USERS } from '@/stories/users'
 
-const WIDGET_API_KEY =
-  '6kQypJppcK9F5FMGHxUM53rc3Kx%2FPFz%2Bi3wni6geNSf%2FIbUq06e5KES8IyR7bKViR11ZM5AabP'
-const INTEGRATION_SLUG = 'storybook-demo-stripe-54511'
 type WIDGET_VARIANTS =
   | 'byPercentage'
   | 'byPercentageOfRevenue'
@@ -27,11 +24,11 @@ const meta = {
   title: 'Widget SDK/Billing Widgets',
   tags: ['autodocs'],
   render: (args) => {
-    const { apiKey, integrationSlug, widgetType, widgetArgs, locale } = args
+    const { apiKey, integrationSlug, widgetType, widgetArgs, locale, user } = args
 
     const widgets = new GreensparkWidgets({
-      apiKey,
-      integrationSlug,
+      apiKey: apiKey || USERS[user].apiKey,
+      integrationSlug: integrationSlug || USERS[user].integrationSlug,
       locale,
     })
 
@@ -68,23 +65,37 @@ const meta = {
     }
   },
   argTypes: {
-    apiKey: { control: 'text' },
-    integrationSlug: { control: 'text' },
+    user: {
+      control: { type: 'select' },
+      options: Object.keys(USERS),
+    },
     locale: {
       control: { type: 'select' },
       options: AVAILABLE_LOCALES,
     },
+    apiKey: {
+      control: 'text',
+      name: 'API Key (overwrite the test user apiKey)',
+      description: 'overwrite the test user apiKey',
+    },
+    integrationSlug: {
+      control: 'text',
+      name: 'Integration Slug (overwrite the test user integrationSlug)',
+      description: 'overwrite the test user integrationSlug',
+    },
   },
   args: {
-    apiKey: WIDGET_API_KEY,
-    integrationSlug: INTEGRATION_SLUG,
+    user: 'SINGULAR',
     locale: 'en',
+    apiKey: '',
+    integrationSlug: '',
   },
 } satisfies Meta<
   GreensparkWidgets & {
     widgetType: WIDGET_VARIANTS
     widgetArgs: unknown
     locale: (typeof AVAILABLE_LOCALES)[number]
+    user: keyof typeof USERS
   }
 >
 

--- a/widgets/src/stories/ByPercentageWidgets.stories.ts
+++ b/widgets/src/stories/ByPercentageWidgets.stories.ts
@@ -1,13 +1,10 @@
 import { AVAILABLE_LOCALES, IMPACT_TYPES } from '@/constants'
-
 import type { StoryObj, Meta } from '@storybook/html'
 import type GreensparkWidgets from '@/index'
 import { ConnectionHandler } from '@/network'
 import type { WidgetStyle } from '@/interfaces'
+import { PREVIEWS_USER } from '@/stories/users'
 
-const WIDGET_API_KEY =
-  '6kQypJppcK9F5FMGHxUM53rc3Kx%2FPFz%2Bi3wni6geNSf%2FIbUq06e5KES8IyR7bKViR11ZM5AabP'
-const INTEGRATION_SLUG = 'GS_PREVIEW'
 type WIDGET_VARIANTS = 'byPercentage' | 'byPercentageOfRevenue'
 
 const meta = {
@@ -29,8 +26,8 @@ const meta = {
     ]
 
     const handler = new ConnectionHandler({
-      apiKey: WIDGET_API_KEY,
-      integrationSlug: INTEGRATION_SLUG,
+      apiKey: PREVIEWS_USER.apiKey,
+      integrationSlug: PREVIEWS_USER.integrationSlug,
       locale: locale,
       isShopifyIntegration: false,
     })

--- a/widgets/src/stories/Widgets.stories.ts
+++ b/widgets/src/stories/Widgets.stories.ts
@@ -5,7 +5,6 @@ import {
   IMPACT_TYPES,
   WIDGET_COLORS,
 } from '@/constants'
-
 import type { StoryObj, Meta } from '@storybook/html'
 import type {
   ByPercentageOfRevenueWidgetParams,
@@ -20,10 +19,8 @@ import type {
 } from '@/interfaces'
 import GreensparkWidgets from '@/index'
 import type { Widget } from '@/widgets/base'
+import { STORE_USERS as USERS } from '@/stories/users'
 
-const WIDGET_API_KEY =
-  '6kQypJppcK9F5FMGHxUM53rc3Kx%2FPFz%2Bi3wni6geNSf%2FIbUq06e5KES8IyR7bKViR11ZM5AabP'
-const INTEGRATION_SLUG = 'greenspark-development-store-widget-sdk-storybook.myshopify.com'
 type WIDGET_VARIANTS =
   | 'byPercentage'
   | 'byPercentageOfRevenue'
@@ -39,11 +36,11 @@ const meta = {
   title: 'Widget SDK/Store Widgets',
   tags: ['autodocs'],
   render: (args) => {
-    const { apiKey, integrationSlug, widgetType, widgetArgs, locale } = args
+    const { apiKey, integrationSlug, widgetType, widgetArgs, locale, user } = args
 
     const widgets = new GreensparkWidgets({
-      apiKey,
-      integrationSlug,
+      apiKey: apiKey || USERS[user].apiKey,
+      integrationSlug: integrationSlug || USERS[user].integrationSlug,
       locale,
     })
 
@@ -138,23 +135,37 @@ const meta = {
     }
   },
   argTypes: {
-    apiKey: { control: 'text' },
-    integrationSlug: { control: 'text' },
+    user: {
+      control: { type: 'select' },
+      options: Object.keys(USERS),
+    },
     locale: {
       control: { type: 'select' },
       options: AVAILABLE_LOCALES,
     },
+    apiKey: {
+      control: 'text',
+      name: 'API Key (overwrite the test user apiKey)',
+      description: 'overwrite the test user apiKey',
+    },
+    integrationSlug: {
+      control: 'text',
+      name: 'Integration Slug (overwrite the test user integrationSlug)',
+      description: 'overwrite the test user integrationSlug',
+    },
   },
   args: {
-    apiKey: WIDGET_API_KEY,
-    integrationSlug: INTEGRATION_SLUG,
+    user: 'SINGULAR',
     locale: 'en',
+    apiKey: '',
+    integrationSlug: '',
   },
 } satisfies Meta<
   GreensparkWidgets & {
     widgetType: WIDGET_VARIANTS
     widgetArgs: unknown
     locale: (typeof AVAILABLE_LOCALES)[number]
+    user: keyof typeof USERS
   }
 >
 
@@ -226,9 +237,9 @@ export const Cart: StoryObj<{ widgetArgs: CartWidgetParams; widgetType: keyof Gr
         color: 'beige',
         withPopup: true,
         order: {
-          lineItems: [{ productId: '1234', quantity: 1 }],
+          lineItems: [{ productId: '1234', quantity: 0 }],
           currency: 'EUR',
-          totalPrice: 100,
+          totalPrice: 1,
         },
       },
       widgetType: 'cart',

--- a/widgets/src/stories/users.ts
+++ b/widgets/src/stories/users.ts
@@ -1,0 +1,39 @@
+interface IUser {
+  apiKey: string
+  integrationSlug: string
+}
+
+export const PREVIEWS_USER: IUser = {
+  integrationSlug: 'GS_PREVIEW',
+  apiKey: '6kQypJppcK9F5FMGHxUM53rc3Kx%2FPFz%2Bi3wni6geNSf%2FIbUq06e5KES8IyR7bKViR11ZM5AabP',
+}
+
+const SINGULAR_STORE: IUser = {
+  integrationSlug: 'greenspark-development-store-widget-sdk-storybook-singular.myshopify.com',
+  apiKey: '%2FugzIyv04LoEscwfOFe6TKTwc%2FgSzNCJSg3rBeDmpH2DNWTUm0YyQrNj%2BIt3q51%2BvE0gz2%2',
+}
+
+const SINGULAR_BILLING: IUser = {
+  integrationSlug: '-storybook-demo---singular--stripe-56010',
+  apiKey: '%2FugzIyv04LoEscwfOFe6TKTwc%2FgSzNCJSg3rBeDmpH2DNWTUm0YyQrNj%2BIt3q51%2BvE0gz2%2',
+}
+
+const PLURAL_STORE: IUser = {
+  integrationSlug: 'greenspark-development-store-widget-sdk-storybook.myshopify.com',
+  apiKey: '6kQypJppcK9F5FMGHxUM53rc3Kx%2FPFz%2Bi3wni6geNSf%2FIbUq06e5KES8IyR7bKViR11ZM5AabP',
+}
+
+const PLURAL_BILLING: IUser = {
+  integrationSlug: 'storybook-demo-stripe-54511',
+  apiKey: '6kQypJppcK9F5FMGHxUM53rc3Kx%2FPFz%2Bi3wni6geNSf%2FIbUq06e5KES8IyR7bKViR11ZM5AabP',
+}
+
+export const STORE_USERS = {
+  SINGULAR: SINGULAR_STORE,
+  PLURAL: PLURAL_STORE,
+} as const
+
+export const BILLING_USERS = {
+  SINGULAR: SINGULAR_BILLING,
+  PLURAL: PLURAL_BILLING,
+} as const


### PR DESCRIPTION
Description: adding a selector to choose from the predefined test users to use their apiKey/integrationSlug. Could be overwritten by manually filling out the dedicated apiKey/integrationSlug inputs