### PR TITLE
Fix cart drawer widget render

### DIFF
--- a/widgets-shopify/package-lock.json
+++ b/widgets-shopify/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@getgreenspark/widgets-shopify",
-  "version": "1.3.2",
+  "version": "1.3.3-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@getgreenspark/widgets-shopify",
-      "version": "1.3.2",
+      "version": "1.3.3-0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.9.1",

--- a/widgets-shopify/package-lock.json
+++ b/widgets-shopify/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@getgreenspark/widgets-shopify",
-  "version": "1.3.3-1",
+  "version": "1.3.3-2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@getgreenspark/widgets-shopify",
-      "version": "1.3.3-1",
+      "version": "1.3.3-2",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.9.1",

--- a/widgets-shopify/package-lock.json
+++ b/widgets-shopify/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@getgreenspark/widgets-shopify",
-  "version": "1.3.3-5",
+  "version": "1.3.3-6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@getgreenspark/widgets-shopify",
-      "version": "1.3.3-5",
+      "version": "1.3.3-6",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.9.1",

--- a/widgets-shopify/package-lock.json
+++ b/widgets-shopify/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@getgreenspark/widgets-shopify",
-  "version": "1.3.3-2",
+  "version": "1.3.3-3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@getgreenspark/widgets-shopify",
-      "version": "1.3.3-2",
+      "version": "1.3.3-3",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.9.1",

--- a/widgets-shopify/package-lock.json
+++ b/widgets-shopify/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@getgreenspark/widgets-shopify",
-  "version": "1.3.3-3",
+  "version": "1.3.3-4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@getgreenspark/widgets-shopify",
-      "version": "1.3.3-3",
+      "version": "1.3.3-4",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.9.1",

--- a/widgets-shopify/package-lock.json
+++ b/widgets-shopify/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@getgreenspark/widgets-shopify",
-  "version": "1.3.3-0",
+  "version": "1.3.3-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@getgreenspark/widgets-shopify",
-      "version": "1.3.3-0",
+      "version": "1.3.3-1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.9.1",

--- a/widgets-shopify/package-lock.json
+++ b/widgets-shopify/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@getgreenspark/widgets-shopify",
-  "version": "1.3.3-4",
+  "version": "1.3.3-5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@getgreenspark/widgets-shopify",
-      "version": "1.3.3-4",
+      "version": "1.3.3-5",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.9.1",

--- a/widgets-shopify/package.json
+++ b/widgets-shopify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getgreenspark/widgets-shopify",
-  "version": "1.3.3-1",
+  "version": "1.3.3-2",
   "bugs": {
     "url": "https://github.com/getgreenspark/sdks/issues"
   },

--- a/widgets-shopify/package.json
+++ b/widgets-shopify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getgreenspark/widgets-shopify",
-  "version": "1.3.3-4",
+  "version": "1.3.3-5",
   "bugs": {
     "url": "https://github.com/getgreenspark/sdks/issues"
   },

--- a/widgets-shopify/package.json
+++ b/widgets-shopify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getgreenspark/widgets-shopify",
-  "version": "1.3.3-3",
+  "version": "1.3.3-4",
   "bugs": {
     "url": "https://github.com/getgreenspark/sdks/issues"
   },

--- a/widgets-shopify/package.json
+++ b/widgets-shopify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getgreenspark/widgets-shopify",
-  "version": "1.3.3-0",
+  "version": "1.3.3-1",
   "bugs": {
     "url": "https://github.com/getgreenspark/sdks/issues"
   },

--- a/widgets-shopify/package.json
+++ b/widgets-shopify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getgreenspark/widgets-shopify",
-  "version": "1.3.2",
+  "version": "1.3.3-0",
   "bugs": {
     "url": "https://github.com/getgreenspark/sdks/issues"
   },

--- a/widgets-shopify/package.json
+++ b/widgets-shopify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getgreenspark/widgets-shopify",
-  "version": "1.3.3-2",
+  "version": "1.3.3-3",
   "bugs": {
     "url": "https://github.com/getgreenspark/sdks/issues"
   },

--- a/widgets-shopify/package.json
+++ b/widgets-shopify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getgreenspark/widgets-shopify",
-  "version": "1.3.3-5",
+  "version": "1.3.3-6",
   "bugs": {
     "url": "https://github.com/getgreenspark/sdks/issues"
   },

--- a/widgets-shopify/src/index.ts
+++ b/widgets-shopify/src/index.ts
@@ -27,12 +27,17 @@ function setupCartDrawerObserver() {
   }
 
   try {
+    const drawer = drawerEl as Element
     cartDrawerObserver = new MutationObserver((mutations) => {
       for (const mutation of mutations) {
         if (mutation.type !== 'childList') continue
         if (cartDrawerDebounceTimer) window.clearTimeout(cartDrawerDebounceTimer)
         cartDrawerDebounceTimer = window.setTimeout(() => {
-          runGreenspark()
+          const hasInstance = Boolean(drawer.querySelector('.greenspark-widget-instance'))
+          const hasTarget = Boolean(drawer.querySelector('.greenspark-widget-target'))
+          if (!hasInstance && hasTarget) {
+            runGreenspark()
+          }
         }, 120)
         break
       }

--- a/widgets-shopify/src/index.ts
+++ b/widgets-shopify/src/index.ts
@@ -10,6 +10,17 @@ const widgetUrl = isDevStore
 const popupHistory: HTMLElement[] = []
 
 const MAX_RETRIES = 5
+const SELECTORS = {
+  cartDrawerForm: '#CartDrawer-Form',
+  cartDrawer: '#CartDrawer',
+  miniCartForm: '#mini-cart-form',
+  miniCart: '#mini-cart',
+  mainCartItems: '#main-cart-items',
+  mainCart: '#main-cart',
+  interactiveCart: 'interactive-cart',
+  cartItemsForm: 'cart-items[form-id]',
+  cartDrawerElement: 'cart-drawer',
+} as const
 let retryCount = 0
 let cartDrawerObserverInitialized = false
 let cartDrawerObserver: MutationObserver | null = null
@@ -18,7 +29,9 @@ let cartDrawerDebounceTimer: number | null = null
 function setupCartDrawerObserver() {
   if (cartDrawerObserverInitialized) return
 
-  const drawerEl = document.querySelector('cart-drawer, #CartDrawer, #mini-cart')
+  const drawerEl = document.querySelector(
+    [SELECTORS.cartDrawerElement, SELECTORS.cartDrawer, SELECTORS.miniCart].join(', '),
+  )
   if (!drawerEl) {
     window.setTimeout(() => {
       if (!cartDrawerObserverInitialized) setupCartDrawerObserver()
@@ -165,17 +178,6 @@ function runGreenspark() {
     const getCheckbox = () => document.querySelector<HTMLInputElement>(checkboxSelector)
     const prevChecked = getCheckbox() ? getCheckbox()!.checked : undefined
     const cartWidgetWindowKey = `greensparkCartWidget-${widgetId}` as GreensparkCartWidgetKey
-
-    const SELECTORS = {
-      cartDrawerForm: '#CartDrawer-Form',
-      cartDrawer: '#CartDrawer',
-      miniCartForm: '#mini-cart-form',
-      miniCart: '#mini-cart',
-      mainCartItems: '#main-cart-items',
-      mainCart: '#main-cart',
-      interactiveCart: 'interactive-cart',
-      cartItemsForm: 'cart-items[form-id]',
-    }
 
     const ensureHandlers = () => {
       const WIDGET_PRESELECT_OPT_OUT_KEY = 'greenspark-preselect-optout'

--- a/widgets-shopify/src/index.ts
+++ b/widgets-shopify/src/index.ts
@@ -28,20 +28,24 @@ function setupCartDrawerObserver() {
 
   try {
     const drawer = drawerEl as Element
+
     cartDrawerObserver = new MutationObserver((mutations) => {
       for (const mutation of mutations) {
         if (mutation.type !== 'childList') continue
         if (cartDrawerDebounceTimer) window.clearTimeout(cartDrawerDebounceTimer)
+
         cartDrawerDebounceTimer = window.setTimeout(() => {
-          const hasInstance = Boolean(drawer.querySelector('.greenspark-widget-instance'))
-          const hasTarget = Boolean(drawer.querySelector('.greenspark-widget-target'))
-          if (!hasInstance && hasTarget) {
+          const hasWidgetInstance = Boolean(drawer.querySelector('.greenspark-widget-instance'))
+          const hasWidgetTarget = Boolean(drawer.querySelector('.greenspark-widget-target'))
+
+          if (!hasWidgetInstance && hasWidgetTarget) {
             runGreenspark()
           }
         }, 120)
         break
       }
     })
+
     cartDrawerObserver.observe(drawerEl, { childList: true, subtree: true })
     cartDrawerObserverInitialized = true
   } catch (err) {
@@ -70,7 +74,6 @@ function runGreenspark() {
     document.addEventListener('DOMContentLoaded', runGreenspark, { once: true })
   }
 
-  // Ensure observer is attached so we detect cart drawer content refreshes
   setupCartDrawerObserver()
 
   if (!window.GreensparkWidgets) {
@@ -320,15 +323,16 @@ function runGreenspark() {
             if (newDrawerContent !== undefined) existingDrawer.innerHTML = newDrawerContent
           }
 
-          const existingMini =
+          const existingMiniCart =
             document.querySelector(SELECTORS.miniCartForm) ||
             document.querySelector(SELECTORS.miniCart)
-          if (existingMini && sections['mini-cart']) {
+          if (existingMiniCart && sections['mini-cart']) {
             const newMiniDoc = parser.parseFromString(sections['mini-cart'], 'text/html')
             const newMiniContent =
               newMiniDoc.querySelector(SELECTORS.miniCartForm)?.innerHTML ??
               newMiniDoc.querySelector(SELECTORS.miniCart)?.innerHTML
-            if (newMiniContent !== undefined) (existingMini as Element).innerHTML = newMiniContent
+            if (newMiniContent !== undefined)
+              (existingMiniCart as Element).innerHTML = newMiniContent
           }
 
           const newCartDocItems = sections['main-cart-items']

--- a/widgets-shopify/src/index.ts
+++ b/widgets-shopify/src/index.ts
@@ -22,6 +22,7 @@ const SELECTORS = {
   cartDrawerElement: 'cart-drawer',
 } as const
 let retryCount = 0
+let cartDrawerRetryCount = 0
 let cartDrawerObserverInitialized = false
 let cartDrawerObserver: MutationObserver | null = null
 let cartDrawerDebounceTimer: number | null = null
@@ -33,6 +34,13 @@ function setupCartDrawerObserver() {
     [SELECTORS.cartDrawerElement, SELECTORS.cartDrawer, SELECTORS.miniCart].join(', '),
   )
   if (!drawerEl) {
+    if (cartDrawerRetryCount++ >= MAX_RETRIES) {
+      cartDrawerObserverInitialized = true
+      console.warn(
+        'Greenspark Widget - Cart drawer not found after max retries; stopping observer setup',
+      )
+      return
+    }
     window.setTimeout(() => {
       if (!cartDrawerObserverInitialized) setupCartDrawerObserver()
     }, 400)
@@ -61,6 +69,7 @@ function setupCartDrawerObserver() {
 
     cartDrawerObserver.observe(drawerEl, { childList: true, subtree: true })
     cartDrawerObserverInitialized = true
+    cartDrawerRetryCount = 0
   } catch (err) {
     console.warn('Greenspark Widget - Failed to attach cart drawer observer', err)
   }


### PR DESCRIPTION
## Description
Add cart drawer mutation observer that detects the refresh and rerenders the widget after a debounced timeout. Add handling for mini cart drawer type in order to add GS product to the cart without the need for refreshing the page.

### Implementation choices:

### Link to task/bug:
